### PR TITLE
[Enhancement] fetch-pull on finish command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -176,4 +176,7 @@ It will force developers to manage there works( not Task ) with PR.
   
 
 - 💻 __<U>Invoke Sync before pr</U>__
-  > Sync should be invoked to prevent duplicate pushes<!-->End of Placeholder of OH-MY-TASK<-->
+  > Sync should be invoked to prevent duplicate pushes
+
+- 💻 __<U>fetch and pull after checkout on finish command</U>__
+  <!-->End of Placeholder of OH-MY-TASK<-->

--- a/src/task/finish.mjs
+++ b/src/task/finish.mjs
@@ -42,6 +42,8 @@ export async function finish() {
       "Select Branch to checkout:",
       false
     );
+    await git.fetch();
+    await git.pull();
     await git.checkout(branchToCheckout);
     return;
   }


### PR DESCRIPTION
## Abstract
- Currently, if there isn't baseTask during `finish` process, it only checkouts to selected branch.
- usually `finish` is called after `pr`. Which means it has high probabiliy of user's checkout branch has some updates to fetch. + ( Fetching and pull won't have any side effects.)

## Implementation

- add fetch and pull 

## Etc

- N/A

## Checklist before merge

- N/A
