### PR TITLE
[Enhancement] PR command) sync is now optional

### DIFF
--- a/cli/oh-my-task-pr.mjs
+++ b/cli/oh-my-task-pr.mjs
@@ -7,13 +7,27 @@ async function pullRequestCommand() {
   const program = new Command();
   program
     .name("oh-my-task-pr")
+    .option(
+      "-s , --sync",
+      "Sync task list and inject changes in previous commit."
+    )
     .description(
       `Request Pull Request from currently working Task (current branch) to Base branch`
     );
 
   program.parse();
 
-  await pullRequest();
+  const options = program.opts();
+
+  const prOptions = {
+    sync: false,
+  };
+
+  if (options.sync) {
+    prOptions.sync = true;
+  }
+
+  await pullRequest(prOptions);
 }
 
 await pullRequestCommand().catch((error) => console.error(error));

--- a/src/task/pr.mjs
+++ b/src/task/pr.mjs
@@ -3,7 +3,7 @@ import * as git from "../git.mjs";
 import { sync } from "./sync.mjs";
 import chalk from "chalk";
 
-export async function pullRequest() {
+export async function pullRequest(options = { sync: false }) {
   const notStagedList = await git.getUnStaged();
   const unTrackedList = await git.getUnTracked();
   if (notStagedList.length > 0 || unTrackedList.length > 0) {
@@ -27,24 +27,26 @@ export async function pullRequest() {
     return;
   }
 
-  // all git process are ready.
-  // now just update README.md and inject to previous commit & push force
+  // -s , --sync
+  if (options.sync) {
+    // all git process are ready.
+    // now just update README.md and inject to previous commit & push force
 
-  // get previous commit message
-  const commitMessage = git.getPreviousCommitMessage();
-  // reset to HEAD ~ 1
-  await git.dangerouslyResetToPreviousHead();
+    // get previous commit message
+    const commitMessage = git.getPreviousCommitMessage();
+    // reset to HEAD ~ 1
+    await git.dangerouslyResetToPreviousHead();
 
-  // sync readme
-  await sync();
-  // add . ( existing works + readme)
-  await git.add();
-  // commit msg ( use previous message )
-  await git.commit(commitMessage);
-  // push force
-  await git.dangerouslyPush();
+    // sync readme
+    await sync();
+    // add . ( existing works + readme)
+    await git.add();
+    // commit msg ( use previous message )
+    await git.commit(commitMessage);
+    // push force
+    await git.dangerouslyPush();
+  }
 
-  // hello reset me haha
   let taskCollection = await context.manifest.getHistory();
   const currentBranchName = git.getCurrentBranchName();
 


### PR DESCRIPTION
## Abstract

- It was horrible experience when sync got always run while executing pr command. I had to manually discard readMe
- Make `sync` optional
## Implementation
- `-s` , `--sync` argument while calling `pr` will now execute sync

## Etc

- N/A

## Checklist before merge

- N/A
